### PR TITLE
Fix Adolf Schneider character visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This mod modifies Hungary's focus tree and starting conditions.
 A placeholder directory has been created for the portrait of **Adolf Schneider**. To add his image, place a DDS file at:
 
 ```
-UMKGLMOD/gfx/leaders/HUN/portrait_hun_adolf_schneider.dds
+UMKGLMOD/gfx/characters/lista/lista_adolf_schneider_large.dds
 ```
 
 The recommended size for political leader portraits is **156x210** pixels.

--- a/common/characters/ideas_hun_magyar-ideak.txt
+++ b/common/characters/ideas_hun_magyar-ideak.txt
@@ -1,1 +1,2 @@
 characters = {
+}

--- a/common/characters/lista.txt
+++ b/common/characters/lista.txt
@@ -8,7 +8,7 @@ characters = {
 			}
 		}
 		country_leader = {
-			ideology = neutrality
+                    ideology = fascism
 			traits = { old_guard }
 			expire = ""
 		}

--- a/history/countries/HUN - Hungary.txt
+++ b/history/countries/HUN - Hungary.txt
@@ -4,7 +4,7 @@ set_politics = {
     election_frequency = 48
     elections_allowed = no
 }
-set_leader = { name = "Adolf Schneider" ideology = fascism picture = "gfx/leaders/HUN/portrait_hun_adolf_schneider.dds" }
+set_leader = { name = "Adolf Schneider" ideology = fascism picture = "gfx/characters/lista/lista_adolf_schneider_large.dds" }
 
 load_focus_tree = GER_patrik_tree
 add_ideas = { HUN_falhozvert_lofasz HUN_trianon_nagyon_faj HUN_a_ciganyok HUN_jonnek_a_migransok }


### PR DESCRIPTION
## Summary
- fix the empty character file
- set Adolf Schneider's ideology to fascism
- update leader portrait path in Hungary history file
- update README instructions for the portrait location

## Testing
- `apt-get update`
- `apt-get install -y vim-common ripgrep`


------
https://chatgpt.com/codex/tasks/task_e_684f228de38083279817dbe6784479f0